### PR TITLE
Fix erb puppet variables in params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@ class teamspeak::params {
     $systemd_file = 'teamspeak/systemd/teamspeak.erb'
     $version      = '3.0.11.3'
     $arch         = $::architecture
-    $mirror       = 'http://dl.4players.de/ts/releases/<%=version%>/teamspeak3-server_linux-<%=download_arch%>-<%=version%>.tar.gz'
+    $mirror       = 'http://dl.4players.de/ts/releases/<%=@version%>/teamspeak3-server_linux-<%=@download_arch%>-<%=@version%>.tar.gz'
   
     case $::osfamily {
         'Debian': {


### PR DESCRIPTION
Accessing puppet variables in erb templates without @ prefix is no longer allowed.

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Failed to parse inline template: undefined local variable or method `version' for #<Puppet::Parser::TemplateWrapper:0xba6754d> at /etc/puppetlabs/code/environments/production/modules/teamspeak/manifests/init.pp:90:20 at /etc/puppetlabs/code/environments/production/manifests/site.pp:2 on node teamspeak
```

This PR fixes this.