### PR TITLE
Add support for SuSE and initd/systemd selection

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class teamspeak (
     $license_file    = undef,
     $user            = 'teamspeak',
     $group           = 'teamspeak',
-    $init            = 'init', # or systemd
+    $init            = $teamspeak::params::init,
     $home            = '/opt/teamspeak',
     $service         = 'teamspeak',
     ) inherits ::teamspeak::params  {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,45 +87,26 @@ class teamspeak (
   }
 
   $parsed_mirror = inline_template($mirror)
-  exec { 'download_teamspeak':
-    command => "wget -q ${parsed_mirror}",
-    path    => '/usr/bin',
-    cwd     => "${home}/downloads",
-    user    => $user,
-    group   => $group,
-    creates => "${home}/downloads/teamspeak3-server_linux_${arch}-${version}.tar.bz2",
-    require => [
+include '::archive' # NOTE: optional for posix platforms
+
+archive { "${home}/downloads/teamspeak3-server_linux_${arch}-${version}.tar.bz2":
+  ensure          => present,
+  extract         => true,
+  extract_path    => $home,
+  extract_command => "tar -xf %s -C /opt/teamspeak/ --strip 1",
+  source          => $parsed_mirror,
+  checksum        => '19ccd8db5427758d972a864b70d4a1263ebb9628fcc42c3de75ba87de105d179',
+  checksum_type   => 'sha256',
+  creates         => '/opt/teamspeak/ts3server',
+  cleanup         => false,
+  user            => $user,
+  group           => $group,
+  require         => [
       File["${home}/downloads"],
       User[$user],
-      Package['wget'],
-    ],
-  } 
+      ],
+}
 
-  exec { 'unpack_teamspeak':
-    command     => "tar -xf ${home}/downloads/teamspeak3-server_linux_${arch}-${version}.tar.bz2 -C /opt/teamspeak/downloads",
-    path        => '/bin',
-    user        => $user,
-    refreshonly => true,
-    subscribe   => Exec['download_teamspeak'],
-  }
-
-  exec { 'copy_teamspeak':
-    command     => "cp -R teamspeak3-server_linux_${arch}/* ${home}",
-    cwd         => "${home}/downloads",
-    path        => '/bin',
-    user        => $user,
-    refreshonly => true,
-    subscribe   => Exec['unpack_teamspeak'],
-  }
-
-  file { 'delete_temp_teamspeak':
-    ensure    => absent,
-    path      => "${home}/downloads/teamspeak3-server_linux_${arch}",
-    subscribe => Exec['copy_teamspeak'],
-    recurse   => true,
-    purge     => true,
-    force     => true,
-  }
 
   if $license_file != undef {
     file { 'teamspeak_license':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,7 +87,6 @@ class teamspeak (
   }
 
   $parsed_mirror = inline_template($mirror)
-include '::archive' # NOTE: optional for posix platforms
 
 archive { "${home}/downloads/teamspeak3-server_linux_${arch}-${version}.tar.bz2":
   ensure          => present,
@@ -106,7 +105,6 @@ archive { "${home}/downloads/teamspeak3-server_linux_${arch}-${version}.tar.bz2"
       User[$user],
       ],
 }
-
 
   if $license_file != undef {
     file { 'teamspeak_license':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,14 +20,43 @@ class teamspeak::params {
                 $download_arch = 'x86'
             }
         }
+        'Suse': {
+            if $arch == 'x86_64' {
+                $download_arch = 'amd64'
+            } else {
+                $download_arch = 'x86'
+            }
+        }
         default: {
         }
     }
+
+if ($::osfamily == 'Debian') and ($::operatingsystemmajrelease >= '8') {
+    $init = 'systemd'
+}
+if ($::osfamily == 'Debian') and ($::operatingsystemmajrelease < '8') {
+    $init = 'init'
+}
+if ($::osfamily == 'RedHat') and ($::operatingsystemmajrelease >= '7') {
+    $init = 'systemd'
+}
+if ($::osfamily == 'RedHat') and ($::operatingsystemmajrelease < '7') {
+    $init = 'init'
+}
+if ($::osfamily == 'Suse') and ($::operatingsystemmajrelease >= '42') {
+    $init = 'systemd'
+}
+if ($::osfamily == 'Suse') and ($::operatingsystemmajrelease < '42') {
+    $init = 'init'
+}
+
+case 
+
     if !($arch in ['i386', 'amd64', 'x86_64']) {
         fail("${arch} is not currently supported!")
     }
 
-    if !($::osfamily in ['Debian', 'RedHat']) {
+    if !($::osfamily in ['Debian', 'RedHat', 'Suse']) {
         fail("${::osfamily} is not currently supported!")
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,8 +50,6 @@ if ($::osfamily == 'Suse') and ($::operatingsystemmajrelease < '42') {
     $init = 'init'
 }
 
-case 
-
     if !($arch in ['i386', 'amd64', 'x86_64']) {
         fail("${arch} is not currently supported!")
     }
@@ -59,5 +57,4 @@ case
     if !($::osfamily in ['Debian', 'RedHat', 'Suse']) {
         fail("${::osfamily} is not currently supported!")
     }
-
 }

--- a/templates/init/Suse.init.erb
+++ b/templates/init/Suse.init.erb
@@ -1,0 +1,36 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:             teamspeak3
+# Required-Start:       $local_fs $network
+# Required-Stop:        $local_fs $network
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Description:          Teamspeak 3 Server
+### END INIT INFO
+# description: Starts or Stops TeamSpeak 3 Server
+#
+# works on openSuSE 42 Leap Systems (should also work on openSuse 13.x)
+#
+
+USER="<%= @user -%>"
+TS3='<%= @home -%>'
+STARTSCRIPT="$TS3/ts3server_startscript.sh"
+
+cd $TS3
+
+case "$1" in
+        'start')
+                su $USER -c "$STARTSCRIPT start"
+        ;;
+        'stop')
+                su $USER -c "$STARTSCRIPT stop"
+        ;;
+        'restart')
+                su $USER -c "$STARTSCRIPT restart"
+        ;;
+        'status')
+                su $USER -c "$STARTSCRIPT status"
+        ;;
+        *)
+        echo "Usage $0 start|stop|restart|status"
+esac

--- a/templates/systemd/teamspeak.erb
+++ b/templates/systemd/teamspeak.erb
@@ -9,7 +9,7 @@ User=<%= @user %>
 ExecStart=<%= @home -%>/ts3server_startscript.sh start
 ExecStop=<%= @home -%>/ts3server_startscript.sh stop
 ExecReload=<%= @home -%>/ts3server_startscript.sh restart
-Restart=always
+Restart=on-success
 RestartSec=15
 
 [Install]


### PR DESCRIPTION
Added supoprt for openSuse (leap and thumbleweed 42.x)
removed a lot of exec for the download and tar, to follow best practice and not use exec, but archive
Added if clause in params to query for os and version, to select init or systemd; not perfect but works for the defined systems.