### PR TITLE
Set proper chmod for systemd unit file

### DIFF
--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -5,7 +5,7 @@ class teamspeak::service::systemd inherits teamspeak {
     content => template($teamspeak::params::systemd_file),
     owner   => 'root',
     group   => 'root',
-    mode    => '0655',
+    mode    => '0644',
   }
   
   # https://tickets.puppetlabs.com/browse/PUP-3483


### PR DESCRIPTION
systemd doesn't like executable bits being set on unit files:

Aug  1 12:45:44 vagrant-teamspeak systemd: Configuration file /etc/systemd/system/teamspeak.service is marked executable. Please remove executable permission bits. Proceeding anyway.